### PR TITLE
Update clone URL for lrcget-cli repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ This is an early-beta release, so expect bugs and missing features.
 
 ```bash
 # Clone the repository
-git clone https://github.com/musicdock/lrcget
+git clone https://github.com/musicdock/lrcget-cli.git
 cd lrcget-cli
 
 # Build release binary


### PR DESCRIPTION
This pull request updates the repository URL in the `README.md` file to reflect the correct GitHub repository for cloning. This ensures that users are directed to the right project when following the setup instructions.